### PR TITLE
Allow script to run outside of nagios folder, and updated wiki url

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ History
 * Apr 25, 2014: Claudio Kuenzler - cleanup, merge Jeromes code, perfdata output fix (rev 5.1)
 * May 5, 2014: Caspar Smit - Fixed output bug in global check / issue #3 (rev 5.2)
 * Feb 4, 2015: Caspar Smit and cguadall - Allow detection of more than 26 devices / issue #5 (rev 5.3)
+* Feb 4, 2015: Josh Behrends - allow script to run outside of nagios plugins dir / wiki url update  (rev 5.4)
 
 
 

--- a/check_smart.pl
+++ b/check_smart.pl
@@ -100,7 +100,7 @@ if ($opt_d || $opt_g ) {
         }
 
         # Allow all device types currently supported by smartctl
-        # See http://sourceforge.net/apps/trac/smartmontools/wiki/Supported_RAID-Controllers
+        # See http://www.smartmontools.org/wiki/Supported_RAID-Controllers
         if ($opt_i =~ m/(ata|scsi|3ware|areca|hpt|cciss|megaraid|sat)/) {
                 $interface = $opt_i;
         } else {

--- a/check_smart.pl
+++ b/check_smart.pl
@@ -21,6 +21,7 @@
 # Apr 25, 2014: Claudio Kuenzler - cleanup, merge Jeromes code, perfdata output fix (rev 5.1)
 # May 5, 2014: Caspar Smit - Fixed output bug in global check / issue #3 (rev 5.2)
 # Feb 4, 2015: Caspar Smit and cguadall - Allow detection of more than 26 devices / issue #5 (rev 5.3)
+# Feb 4, 2015: Josh Behrends - allow script to run outside of nagios plugins dir / wiki url update  (rev 5.4)
 
 use strict;
 use Getopt::Long;
@@ -28,10 +29,13 @@ use Getopt::Long;
 use File::Basename qw(basename);
 my $basename = basename($0);
 
-my $revision = '$Revision: 5.3 $';
+my $revision = '$Revision: 5.4 $';
 
 use FindBin;
 use lib $FindBin::Bin;
+BEGIN {
+  push @INC,'/usr/lib/nagios/plugins','/usr/lib64/nagios/plugins';
+}
 use utils qw(%ERRORS &print_revision &support &usage);
 
 $ENV{'PATH'}='/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin';
@@ -403,7 +407,7 @@ sub print_help {
         print "\n";
         print "Other options\n";
         print "  -i/--interface: device's interface type\n";
-        print "  (See http://sourceforge.net/apps/trac/smartmontools/wiki/Supported_RAID-Controllers for interface convention)\n";
+        print "  (See http://www.smartmontools.org/wiki/Supported_RAID-Controllers for interface convention)\n";
         print "  -b/--bad: Threshold value (integer) when to warn for N bad entries\n";
         print "  -h/--help: this help\n";
         print "  --debug: show debugging information\n";


### PR DESCRIPTION
This PR allows the script to live and run outside of the nagios plugin dir.
There is also an update to the wiki url referenced in the script.