### PR TITLE
check if $device is initialized.

### DIFF
--- a/check_smart.pl
+++ b/check_smart.pl
@@ -114,7 +114,7 @@ if ($opt_d || $opt_g ) {
 }
 
 
-if ($device eq "") {
+if (!defined($device) || $device eq "") {
     print "must specify a device!\n\n";
     print_help();
     exit $ERRORS{'UNKNOWN'};


### PR DESCRIPTION
If given -d without any argument it'll complain about an unitialized variable. This fixes the behavior
