### PR TITLE
Add device info in output

### DIFF
--- a/check_smart.pl
+++ b/check_smart.pl
@@ -276,14 +276,14 @@ foreach $device ( split(":",$device) ){
 				$output_mode = "ata";
 				warn "(debug) parsing line:\n$line\n\n" if $opt_debug;
 				$serial = $1;
-				$serial =~ s/\s{2,}/ /g;
+				$serial =~ s/^\s+|\s+$//g;
 				warn "(debug) found serial number $serial\n\n" if $opt_debug;
 			}
 			if($line =~ /$line_serial_scsi(.+)/){
 				$output_mode = "scsi";
 				warn "(debug) parsing line:\n$line\n\n" if $opt_debug;
 				$serial = $1;
-				$serial =~ s/\s{2,}/ /g;
+				$serial =~ s/^\s+|\s+$//g;
 				warn "(debug) found serial number $serial\n\n" if $opt_debug;
 			}
 

--- a/check_smart.pl
+++ b/check_smart.pl
@@ -151,7 +151,9 @@ my $exit_status_local = 'OK';
 my $status_string = '';
 my $perf_string = '';
 my $Terminator = ' --- ';
+my $vendor = '';
 my $model = '';
+my $product = '';
 my $serial = '';
 
 # exclude list
@@ -259,19 +261,28 @@ foreach $device ( split(":",$device) ){
 			if($line =~ /$line_vendor_scsi(.+)/){
 				$output_mode = "scsi";
 				warn "(debug) parsing line:\n$line\n\n" if $opt_debug;
-				$model = $1;
-				$model =~ s/^\s+|\s+$//g;
+				$vendor = $1;
+				$vendor =~ s/^\s+|\s+$//g;
 				warn "(debug) found vendor: $model\n\n" if $opt_debug;
 			}
 			if($line =~ /$line_model_scsi(.+)/){
 				$output_mode = "scsi";
 				warn "(debug) parsing line:\n$line\n\n" if $opt_debug;
-				$model .= $1;
+				$product = $1;
+				$product =~ s/^\s+|\s+$//g;
+				$model = "$vendor $product";
 				$model =~ s/^\s+|\s+$//g;
 				warn "(debug) found model: $model\n\n" if $opt_debug;
 			}
 			if($line =~ /$line_serial_ata(.+)/){
 				$output_mode = "ata";
+				warn "(debug) parsing line:\n$line\n\n" if $opt_debug;
+				$serial = $1;
+				$serial =~ s/^\s+|\s+$//g;
+				warn "(debug) found serial number $serial\n\n" if $opt_debug;
+			}
+			if($line =~ /$line_serial_scsi(.+)/){
+				$output_mode = "scsi";
 				warn "(debug) parsing line:\n$line\n\n" if $opt_debug;
 				$serial = $1;
 				$serial =~ s/^\s+|\s+$//g;

--- a/check_smart.pl
+++ b/check_smart.pl
@@ -276,14 +276,14 @@ foreach $device ( split(":",$device) ){
 				$output_mode = "ata";
 				warn "(debug) parsing line:\n$line\n\n" if $opt_debug;
 				$serial = $1;
-				$srial =~ s/\s{2,}/ /g;
+				$serial =~ s/\s{2,}/ /g;
 				warn "(debug) found serial number $serial\n\n" if $opt_debug;
 			}
 			if($line =~ /$line_serial_scsi(.+)/){
 				$output_mode = "scsi";
 				warn "(debug) parsing line:\n$line\n\n" if $opt_debug;
 				$serial = $1;
-				$srial =~ s/\s{2,}/ /g;
+				$serial =~ s/\s{2,}/ /g;
 				warn "(debug) found serial number $serial\n\n" if $opt_debug;
 			}
 

--- a/check_smart.pl
+++ b/check_smart.pl
@@ -255,37 +255,35 @@ foreach $device ( split(":",$device) ){
 				$output_mode = "ata";
 				warn "(debug) parsing line:\n$line\n\n" if $opt_debug;
 				$model = $1;
-				$model =~ s/^\s+|\s+$//g;
+				$model =~ s/\s{2,}/ /g;
 				warn "(debug) found model: $model\n\n" if $opt_debug;
 			}
 			if($line =~ /$line_vendor_scsi(.+)/){
 				$output_mode = "scsi";
 				warn "(debug) parsing line:\n$line\n\n" if $opt_debug;
 				$vendor = $1;
-				$vendor =~ s/^\s+|\s+$//g;
 				warn "(debug) found vendor: $model\n\n" if $opt_debug;
 			}
 			if($line =~ /$line_model_scsi(.+)/){
 				$output_mode = "scsi";
 				warn "(debug) parsing line:\n$line\n\n" if $opt_debug;
 				$product = $1;
-				$product =~ s/^\s+|\s+$//g;
 				$model = "$vendor $product";
-				$model =~ s/^\s+|\s+$//g;
+				$model =~ s/\s{2,}/ /g;
 				warn "(debug) found model: $model\n\n" if $opt_debug;
 			}
 			if($line =~ /$line_serial_ata(.+)/){
 				$output_mode = "ata";
 				warn "(debug) parsing line:\n$line\n\n" if $opt_debug;
 				$serial = $1;
-				$serial =~ s/^\s+|\s+$//g;
+				$srial =~ s/\s{2,}/ /g;
 				warn "(debug) found serial number $serial\n\n" if $opt_debug;
 			}
 			if($line =~ /$line_serial_scsi(.+)/){
 				$output_mode = "scsi";
 				warn "(debug) parsing line:\n$line\n\n" if $opt_debug;
 				$serial = $1;
-				$serial =~ s/^\s+|\s+$//g;
+				$srial =~ s/\s{2,}/ /g;
 				warn "(debug) found serial number $serial\n\n" if $opt_debug;
 			}
 

--- a/check_smart.pl
+++ b/check_smart.pl
@@ -528,7 +528,7 @@ foreach $device ( split(":",$device) ){
 		  }
 		  else {
 			$status_string = "Drive $model S/N $serial: ";
-			$status_string = join(', ', @error_messages);
+			$status_string .= join(', ', @error_messages);
 		  }
 		} 
 		else {


### PR DESCRIPTION
This PR adds the device model and serial number to the output:

```
# ./check_smart -d /dev/sda -i megaraid,12
OK: Drive  WD2000FYYZ-23UL 81Y9795 81Y3864IBM S/N  XXXXXXXXXX: no SMART errors detected. |Raw_Read_Error_Rate=0 Spin_Up_Time=4475 Start_Stop_Count=46 Reallocated_Sector_Ct=0 Seek_Error_Rate=0 Power_On_Hours=41117 Spin_Retry_Count=0 Calibration_Retry_Count=0 Power_Cycle_Count=46 G-Sense_Error_Rate=0 Power-Off_Retract_Count=45 Load_Cycle_Count=0 Temperature_Celsius=31 Hardware_ECC_Recovered=0 Reallocated_Event_Count=0 Current_Pending_Sector=0 Offline_Uncorrectable=0 UDMA_CRC_Error_Count=0 Multi_Zone_Error_Rate=0
```

This should help to identify a failing drive more quickly, especially if hardware raid controller with dynamic positions (e.g megaraid,12, cciss,4, etc) are used.