### PR TITLE
 Remove dependency on Nagios utils.pm

### DIFF
--- a/check_smart.pl
+++ b/check_smart.pl
@@ -50,7 +50,10 @@ use lib $FindBin::Bin;
 BEGIN {
  push @INC,'/usr/lib/nagios/plugins','/usr/lib64/nagios/plugins','/usr/local/libexec/nagios';
 }
-use utils qw(%ERRORS &print_revision &support &usage);
+
+# Standard Nagios return codes
+my %ERRORS=('OK'=>0,'WARNING'=>1,'CRITICAL'=>2,'UNKNOWN'=>3,'DEPENDENT'=>4);
+
 
 $ENV{'PATH'}='/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin';
 $ENV{'BASH_ENV'}='';
@@ -74,7 +77,8 @@ GetOptions(
 );
 
 if ($opt_v) {
-        print_revision($basename,$revision);
+        print "$basename v$revision\n";
+        print "The nagios plugins come with ABSOLUTELY NO WARRANTY. You may redistribute\ncopies of the plugins under the terms of the GNU General Public License.\nFor more information about these matters, see the file named COPYING.\n";
         exit $ERRORS{'OK'};
 }
 

--- a/check_smart.pl
+++ b/check_smart.pl
@@ -77,8 +77,7 @@ GetOptions(
 );
 
 if ($opt_v) {
-        print "$basename v$revision\n";
-        print "The nagios plugins come with ABSOLUTELY NO WARRANTY. You may redistribute\ncopies of the plugins under the terms of the GNU General Public License.\nFor more information about these matters, see the file named COPYING.\n";
+        print_revision($basename, $revision);
         exit $ERRORS{'OK'};
 }
 
@@ -556,6 +555,12 @@ $status_string =~ s/$Terminator$//;
 print "$exit_status: $status_string|$perf_string\n";
 exit $ERRORS{$exit_status};
 
+sub print_revision {
+        ($basename, $revision) = @_;
+        print "$basename v$revision\n";
+        print "The nagios plugins come with ABSOLUTELY NO WARRANTY. You may redistribute\ncopies of the plugins under the terms of the GNU General Public License.\nFor more information about these matters, see the file named COPYING.\n";
+
+}
 
 sub print_help {
         print_revision($basename,$revision);

--- a/check_smart.pl
+++ b/check_smart.pl
@@ -45,12 +45,6 @@ use File::Basename qw(basename);
 my $basename = basename($0);
 my $revision = '6.3';
 
-use FindBin;
-use lib $FindBin::Bin;
-BEGIN {
- push @INC,'/usr/lib/nagios/plugins','/usr/lib64/nagios/plugins','/usr/local/libexec/nagios';
-}
-
 # Standard Nagios return codes
 my %ERRORS=('OK'=>0,'WARNING'=>1,'CRITICAL'=>2,'UNKNOWN'=>3,'DEPENDENT'=>4);
 

--- a/check_smart.pl
+++ b/check_smart.pl
@@ -552,7 +552,7 @@ exit $ERRORS{$exit_status};
 sub print_revision {
         ($basename, $revision) = @_;
         print "$basename v$revision\n";
-        print "The nagios plugins come with ABSOLUTELY NO WARRANTY. You may redistribute\ncopies of the plugins under the terms of the GNU General Public License.\nFor more information about these matters, see the file named COPYING.\n";
+        print "The monitoring plugins come with ABSOLUTELY NO WARRANTY. You may redistribute\ncopies of the plugins under the terms of the GNU General Public License.\nFor more information about these matters, see the file named COPYING.\n";
 
 }
 


### PR DESCRIPTION
There is a dependency on the utils.pm library (shipped in the `nagios-plugins-perl` module on RHEL/CentOS hosts), but it isn't really needed.  Two of the functions referenced are never actually called, and what is used (`%ERRORS` and `&print_revision`) is trivially replaced with code directly in the script.