### PR TITLE
Make -g option available for 3ware and cciss controllers

### DIFF
--- a/check_smart.pl
+++ b/check_smart.pl
@@ -129,6 +129,12 @@ if ($opt_d || $opt_g ) {
               $interface .= "megaraid," . $k . ":";
             }
           }
+          elsif($interface =~ m/3ware,\[(\d{1,2})-(\d{1,2})\]/) {
+            $interface = "";
+            for(my $k = $1; $k <= $2; $k++) {
+              $interface .= "3ware," . $k . ":";
+            }
+          }
           else {
             $interface .= ":";
           }

--- a/check_smart.pl
+++ b/check_smart.pl
@@ -135,6 +135,12 @@ if ($opt_d || $opt_g ) {
               $interface .= "3ware," . $k . ":";
             }
           }
+          elsif($interface =~ m/cciss,\[(\d{1,2})-(\d{1,2})\]/) {
+            $interface = "";
+            for(my $k = $1; $k <= $2; $k++) {
+              $interface .= "cciss," . $k . ":";
+            }
+          }
           else {
             $interface .= ":";
           }

--- a/check_smart.pl
+++ b/check_smart.pl
@@ -127,18 +127,21 @@ if ($opt_d || $opt_g ) {
             $interface = "";
             for(my $k = $1; $k <= $2; $k++) {
               $interface .= "megaraid," . $k . ":";
+              $label = "[$interface] - ";
             }
           }
           elsif($interface =~ m/3ware,\[(\d{1,2})-(\d{1,2})\]/) {
             $interface = "";
             for(my $k = $1; $k <= $2; $k++) {
               $interface .= "3ware," . $k . ":";
+              $label = "[$interface] - ";
             }
           }
           elsif($interface =~ m/cciss,\[(\d{1,2})-(\d{1,2})\]/) {
             $interface = "";
             for(my $k = $1; $k <= $2; $k++) {
               $interface .= "cciss," . $k . ":";
+              $label = "[$interface] - ";
             }
           }
           else {
@@ -211,7 +214,11 @@ foreach $device ( split(":",$device) ){
 			# we had a pattern based on $opt_g
 			$tag   = $device;
 			$tag   =~ s/$opt_g//;
-			$label = "[$device] - ";
+                        if($interface =~ qr/(?:megaraid|3ware|cciss)/){ 
+			  $label = "[$interface] - "; 
+                        } else {
+			  $label = "[$device] - ";
+                        }
 		} else {
 			# we had a device specified using $opt_d (traditional)
 			$label = "";

--- a/check_smart.pl
+++ b/check_smart.pl
@@ -127,21 +127,18 @@ if ($opt_d || $opt_g ) {
             $interface = "";
             for(my $k = $1; $k <= $2; $k++) {
               $interface .= "megaraid," . $k . ":";
-              $label = "[$interface] - ";
             }
           }
           elsif($interface =~ m/3ware,\[(\d{1,2})-(\d{1,2})\]/) {
             $interface = "";
             for(my $k = $1; $k <= $2; $k++) {
               $interface .= "3ware," . $k . ":";
-              $label = "[$interface] - ";
             }
           }
           elsif($interface =~ m/cciss,\[(\d{1,2})-(\d{1,2})\]/) {
             $interface = "";
             for(my $k = $1; $k <= $2; $k++) {
               $interface .= "cciss," . $k . ":";
-              $label = "[$interface] - ";
             }
           }
           else {

--- a/check_smart.pl
+++ b/check_smart.pl
@@ -39,13 +39,14 @@
 # Oct 1, 2019: Michael Krahe - Allow exclusion from perfdata as well (-E) and by attribute number (6.3)
 # Oct 29, 2019: Jesse Becker - Remove dependency on utils.pm, add quiet parameter (6.4)
 # Nov 22, 2019: Claudio Kuenzler - Add Reported_Uncorrect and Reallocated_Event_Count to default raw list (6.5)
+# Nov 29, 2019: Claudio Kuenzler - Add 3ware and cciss devices for global (-g) check, adjust output (6.6)
 
 use strict;
 use Getopt::Long;
 use File::Basename qw(basename);
 
 my $basename = basename($0);
-my $revision = '6.5';
+my $revision = '6.6';
 
 # Standard Nagios return codes
 my %ERRORS=('OK'=>0,'WARNING'=>1,'CRITICAL'=>2,'UNKNOWN'=>3,'DEPENDENT'=>4);


### PR DESCRIPTION
The feature was requested in #30 . This PR adds the possibility to use `3ware,N` and `cciss,N` drives in combination with the global `-g` parameter.

Furthermore this PR adjusts the output of the plugin when the `-g` is used in combination with hardware raid controllers. Instead of showing the logical device name (/dev/sda for example), the plugin will now show the controller with drive number:

```
# ./check_smart.pl -g /dev/sda -i 'cciss,[1-3]'
OK: [cciss,1] - Device is clean --- [cciss,2] - Device is clean --- [cciss,3] - Device is clean|
```