### PR TITLE
6.9.0

### DIFF
--- a/check_smart.pl
+++ b/check_smart.pl
@@ -196,7 +196,7 @@ my @raw_check_list_nvme = split /,/, $raw_check_list_nvme;
 
 # warning threshold list (for raw checks)
 my $warn_list = $opt_w // '';
-my $warn_list = $opt_w // 'Percent_Lifetime_Remain=90' if $opt_l;
+$warn_list = $opt_w // 'Percent_Lifetime_Remain=90' if $opt_l;
 my @warn_list = split /,/, $warn_list;
 my %warn_list;
 my $warn_key;

--- a/check_smart.pl
+++ b/check_smart.pl
@@ -45,14 +45,15 @@
 # Jun 2, 2020: Claudio Kuenzler - Bugfix to make --warn work (6.7.1)
 # Oct 14, 2020: Claudio Kuenzler - Allow skip self-assessment check (--skip-self-assessment) (6.8.0)
 # Oct 14, 2020: Claudio Kuenzler - Add Command_Timeout to default raw list (6.8.0)
-# Nov 11, 2020: Evan Felix - Allow use of : in pathnames so /dev/disk/by-path/ device names work
+# Mar 3, 2021: Evan Felix - Allow use of colons in pathnames so /dev/disk/by-path/ device names work (6.9.0)
+# Mar 3, 2021: Claudio Kuenzler - Add SSD attribute 202 Percent_Lifetime_Remain to default raw list (6.9.0)
 
 use strict;
 use Getopt::Long;
 use File::Basename qw(basename);
 
 my $basename = basename($0);
-my $revision = '6.8.0';
+my $revision = '6.9.0';
 
 # Standard Nagios return codes
 my %ERRORS=('OK'=>0,'WARNING'=>1,'CRITICAL'=>2,'UNKNOWN'=>3,'DEPENDENT'=>4);
@@ -184,7 +185,7 @@ my @exclude_perfdata = split /,/, $opt_E // '';
 push(@exclude_checks, @exclude_perfdata);
 
 # raw check list
-my $raw_check_list = $opt_r // 'Current_Pending_Sector,Reallocated_Sector_Ct,Program_Fail_Cnt_Total,Uncorrectable_Error_Cnt,Offline_Uncorrectable,Runtime_Bad_Block,Reported_Uncorrect,Reallocated_Event_Count,Command_Timeout';
+my $raw_check_list = $opt_r // 'Current_Pending_Sector,Reallocated_Sector_Ct,Program_Fail_Cnt_Total,Uncorrectable_Error_Cnt,Offline_Uncorrectable,Runtime_Bad_Block,Reported_Uncorrect,Reallocated_Event_Count,Percent_Lifetime_Remain';
 my @raw_check_list = split /,/, $raw_check_list;
 
 # raw check list for nvme
@@ -192,7 +193,7 @@ my $raw_check_list_nvme = $opt_r // 'Media_and_Data_Integrity_Errors';
 my @raw_check_list_nvme = split /,/, $raw_check_list_nvme;
 
 # warning threshold list (for raw checks)
-my $warn_list = $opt_w // '';
+my $warn_list = $opt_w // 'Percent_Lifetime_Remain=90';
 my @warn_list = split /,/, $warn_list;
 my %warn_list;
 my $warn_key;


### PR DESCRIPTION
This PR is for release 6.9.0.
It bumps the changelog for PR #64, which allows to use PCI device paths (such as `/dev/disk/by-path/pci-0000:00:11.5-ata-5.0`).
A new optional parameter `-l` / `--ssd-lifetime` is introduced. By using this parameter, check_smart will additionally check the SMART attribute "Percent_Lifetime_Remain" which exists on some SSD drives (seen on Crucial MX drives). 

Without `-l`parameter:

```
# ./check_smart.pl -d /dev/sda -i ata 
WARNING: Drive  CT1000MX500SSD1 S/N XXX:  Reallocated_Event_Count is non-zero (12), Attribute Percent_Lifetime_Remain failed at FAILING_NOW|Raw_Read_Error_Rate=0 Reallocate_NAND_Blk_Cnt=12 Power_On_Hours=10977 Power_Cycle_Count=19 Program_Fail_Count=0 Erase_Fail_Count=12 Ave_Block-Erase_Count=1489 Unexpect_Power_Loss_Ct=16 Unused_Reserve_NAND_Blk=42 SATA_Interfac_Downshift=0 Error_Correction_Count=0 Reported_Uncorrect=0 Temperature_Celsius=42 Reallocated_Event_Count=12 Current_Pending_ECC_Cnt=0 Offline_Uncorrectable=0 UDMA_CRC_Error_Count=5 Percent_Lifetime_Remain=99 Write_Error_Rate=0 Success_RAIN_Recov_Cnt=0 Total_LBAs_Written=29727639281 Host_Program_Page_Count=22559806254 FTL_Program_Page_Count=39991540993
```

With `-l` parameter adds attribute value check with a default warning level at 90:

```
# ./check_smart.pl -d /dev/sda -i ata -l
WARNING: Drive  CT1000MX500SSD1 S/N XXX:  Reallocated_Event_Count is non-zero (12), Attribute Percent_Lifetime_Remain failed at FAILING_NOW, Percent_Lifetime_Remain is non-zero (99)|Raw_Read_Error_Rate=0 Reallocate_NAND_Blk_Cnt=12 Power_On_Hours=10977 Power_Cycle_Count=19 Program_Fail_Count=0 Erase_Fail_Count=12 Ave_Block-Erase_Count=1489 Unexpect_Power_Loss_Ct=16 Unused_Reserve_NAND_Blk=42 SATA_Interfac_Downshift=0 Error_Correction_Count=0 Reported_Uncorrect=0 Temperature_Celsius=42 Reallocated_Event_Count=12 Current_Pending_ECC_Cnt=0 Offline_Uncorrectable=0 UDMA_CRC_Error_Count=5 Percent_Lifetime_Remain=99 Write_Error_Rate=0 Success_RAIN_Recov_Cnt=0 Total_LBAs_Written=29728798703 Host_Program_Page_Count=22560954702 FTL_Program_Page_Count=39992573131
```

The default warning threshold of 90 can be overwritten using the already existing `-w` / `--warn` parameter:

```
# ./check_smart.pl -d /dev/sda -i ata -l -w "Percent_Lifetime_Remain=100"
WARNING: Drive  CT1000MX500SSD1 S/N XXX:  Reallocated_Event_Count is non-zero (12), Attribute Percent_Lifetime_Remain failed at FAILING_NOW, Percent_Lifetime_Remain is non-zero (99) (but less than threshold 100)|Raw_Read_Error_Rate=0 Reallocate_NAND_Blk_Cnt=12 Power_On_Hours=10977 Power_Cycle_Count=19 Program_Fail_Count=0 Erase_Fail_Count=12 Ave_Block-Erase_Count=1489 Unexpect_Power_Loss_Ct=16 Unused_Reserve_NAND_Blk=42 SATA_Interfac_Downshift=0 Error_Correction_Count=0 Reported_Uncorrect=0 Temperature_Celsius=42 Reallocated_Event_Count=12 Current_Pending_ECC_Cnt=0 Offline_Uncorrectable=0 UDMA_CRC_Error_Count=5 Percent_Lifetime_Remain=99 Write_Error_Rate=0 Success_RAIN_Recov_Cnt=0 Total_LBAs_Written=29728758086 Host_Program_Page_Count=22560921678 FTL_Program_Page_Count=39992573096
```

