### PR TITLE
Show any warnings or errors which may have been muted in -g mode

### DIFF
--- a/check_smart.pl
+++ b/check_smart.pl
@@ -704,10 +704,16 @@ foreach $device ( split("\\|",$device) ){
 			$status_string .= join(', ', @warning_messages);
 		  }
 		  push @drives_status_not_okay, $status_string;
-		} 
+		}
 		else {
 		  if ($opt_g) {
 			$status_string = $label."Device is clean";
+			if (scalar(@error_messages) > 0) {
+				$status_string .= " ".$label.join(', ', @error_messages);
+			}
+			if (scalar(@warning_messages) > 0) {
+				$status_string .= " ".$label.join(', ', @warning_messages);
+			}
 		  }
 		  else {
 			$drive_details = "Drive $model S/N $serial: no SMART errors detected. ";


### PR DESCRIPTION
It looks like this:
`[/dev/sda] - Device is clean --- [/dev/sdc] - Device is clean [/dev/sdc] - Reported_Uncorrect is non-zero (56) (but less than threshold 60) --- [/dev/sdd] - Device is clean`