### PR TITLE
Add --hide-sn parameter

### DIFF
--- a/check_smart.pl
+++ b/check_smart.pl
@@ -71,7 +71,7 @@ my @sys_path = qw(/usr/bin /bin /usr/sbin /sbin /usr/local/bin /usr/local/sbin);
 $ENV{'BASH_ENV'}='';
 $ENV{'ENV'}='';
 
-use vars qw($opt_b $opt_d $opt_g $opt_debug $opt_h $opt_i $opt_e $opt_E $opt_r $opt_s $opt_v $opt_w $opt_q $opt_l $opt_skip_sa $opt_skip_temp);
+use vars qw($opt_b $opt_d $opt_g $opt_debug $opt_h $opt_i $opt_e $opt_E $opt_r $opt_s $opt_v $opt_w $opt_q $opt_l $opt_skip_sa $opt_skip_temp $opt_hide_sn);
 Getopt::Long::Configure('bundling');
 GetOptions(
                           "debug"         => \$opt_debug,
@@ -90,6 +90,7 @@ GetOptions(
         "l"   => \$opt_l, "ssd-lifetime"  => \$opt_l,
 			  "skip-self-assessment" => \$opt_skip_sa,
 			  "skip-temp-check" => \$opt_skip_temp,
+			  "hide-sn" => \$opt_hide_sn,
 );
 
 if ($opt_v) {
@@ -356,8 +357,13 @@ foreach $device ( split("\\|",$device) ){
 			}
 			if($line =~ /$line_serial_ata(.+)/){
 				warn "(debug) parsing line:\n$line\n\n" if $opt_debug;
-				$serial = $1;
-				$serial =~ s/^\s+|\s+$//g;
+				if($opt_hide_sn) {
+				  $serial = "<HIDDEN>";
+				  warn "(debug) Hiding serial number\n\n" if $opt_debug;
+				} else {
+				  $serial = $1;
+				  $serial =~ s/^\s+|\s+$//g;
+				}
 				warn "(debug) found serial number $serial\n\n" if $opt_debug;
 			}
 			if($line =~ /$line_serial_scsi(.+)/){


### PR DESCRIPTION
This PR adds a new parameter `--hide-sn` to hide the serial number of the drive(s).

```
root@nas:~/check_smart# ./check_smart.pl -d /dev/sdf -i auto --hide-sn
OK: Drive  WDC WD20SPZX-22CRAT0 S/N <HIDDEN>: no SMART errors detected. |Raw_Read_Error_Rate=0 Spin_Up_Time=1850 Start_Stop_Count=8 Reallocated_Sector_Ct=0 Seek_Error_Rate=0 Power_On_Hours=38056 Spin_Retry_Count=0 Calibration_Retry_Count=0 Power_Cycle_Count=6 Power-Off_Retract_Count=4 Load_Cycle_Count=1239994 Temperature_Celsius=29 Reallocated_Event_Count=0 Current_Pending_Sector=0 Offline_Uncorrectable=0 UDMA_CRC_Error_Count=0 Multi_Zone_Error_Rate=0
```