### PR TITLE
add areca support for multi device

### DIFF
--- a/check_smart.pl
+++ b/check_smart.pl
@@ -187,6 +187,12 @@ if ($opt_d || $opt_g ) {
               $interface .= "usbjmicron," . $k . "|";
             }
           }
+          elsif($interface =~ m/areca,\[(\d{1,2})-(\d{1,2})\]/) {
+            $interface = "";
+            for(my $k = $1; $k <= $2; $k++) {
+              $interface .= "areca," . $k . "|";
+            }
+          }
           else {
             $interface .= "|";
           }
@@ -280,7 +286,7 @@ foreach $device ( split("\\|",$device) ){
 			# we had a pattern based on $opt_g
 			$tag   = $device;
 			$tag   =~ s/\Q$opt_g\E//;
-                        if($interface =~ qr/(?:megaraid|3ware|aacraid|cciss)/){
+                        if($interface =~ qr/(?:megaraid|3ware|aacraid|cciss|areca)/){
 			  $label = "[$interface] - "; 
                         } else {
 			  $label = "[$device] - ";


### PR DESCRIPTION
Add possibility to use check_smart.pl -g "regex" -i "areca,[1-4]"

I made a test : 
`check_smart.pl -g /dev/sg1 -i "areca,[1-4]"`
`OK: [areca,1] - Device is clean --- [areca,2] - Device is clean --- [areca,3] - Device is clean --- [areca,4] - Device is clean|`